### PR TITLE
Reload dining hall list after opening activity via back button

### DIFF
--- a/app/src/main/java/com/adisa/diningplus/MainActivity.java
+++ b/app/src/main/java/com/adisa/diningplus/MainActivity.java
@@ -67,7 +67,7 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.C
         setTheme(R.style.AppTheme);
 
         adapter = new MainListAdapter(this);
-        ListView mainList = (ListView) findViewById(R.id.hallList);
+        ListView mainList = findViewById(R.id.hallList);
         mainList.setAdapter(adapter);
         mainList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             public void onItemClick(AdapterView<?> parent, View v,
@@ -79,7 +79,7 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.C
                 startActivity(i);
             }
         });
-        swipeContainer = (SwipeRefreshLayout) findViewById(R.id.swipeContainer);
+        swipeContainer = findViewById(R.id.swipeContainer);
 
         swipeContainer.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
@@ -90,7 +90,7 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.C
         });
         swipeContainer.setColorSchemeResources(R.color.colorAccent);
 
-        coordinatorLayout = (CoordinatorLayout) findViewById(R.id.snackbar);
+        coordinatorLayout = findViewById(R.id.snackbar);
 
         if (mGoogleApiClient == null) {
             mGoogleApiClient = new GoogleApiClient.Builder(this)
@@ -159,7 +159,7 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.C
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         if (grantResults.length > 0
                 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
             currentLocation = LocationServices.FusedLocationApi.getLastLocation(

--- a/app/src/main/java/com/adisa/diningplus/MainActivity.java
+++ b/app/src/main/java/com/adisa/diningplus/MainActivity.java
@@ -153,6 +153,12 @@ public class MainActivity extends AppCompatActivity implements GoogleApiClient.C
     }
 
     @Override
+    protected void onResume() {
+        adapter.notifyDataSetChanged();
+        super.onResume();
+    }
+
+    @Override
     public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
         if (grantResults.length > 0
                 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {


### PR DESCRIPTION
This fixes distance units not updating in the dining hall list after the user changes the preferences.